### PR TITLE
fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 os: linux
-node_js: latest
+node_js: "node"
+

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "main": "node_modules/expo/AppEntry.js",
   "private": true,
   "scripts": {
-    "prettier": "prettier --list-different **/*.js",
-    "prettier-fix": "prettier --list-different --write **/*.js",
+    "prettier": "prettier --check \"**/*.js\"",
+    "prettier-fix": "prettier --write \"**/*.js\"",
     "lint": "npm run prettier",
     "test": "npm run lint"
   },


### PR DESCRIPTION
Giving "node" as a version parameter should always use the latest Node.js version.

Fixes #10 