### PR TITLE
reset game state before leaving the game screen

### DIFF
--- a/js/context/actions/gameActions.js
+++ b/js/context/actions/gameActions.js
@@ -9,6 +9,14 @@ import { getChoices, getHearts, updateScore } from '../../utils/logic';
   spawnGems = executing the gem spawn animation and addition
 */
 
+export const resetGameState = state => ({
+  game: {
+    ...state,
+    lives: 3,
+    score: 0
+  }
+});
+
 export const setupNextSyllable = (state, selectedKana, selectedLevel) => {
   const availableSyllables = _.filter(
     kana[selectedKana],

--- a/js/screens/game/AnswerButton.js
+++ b/js/screens/game/AnswerButton.js
@@ -19,13 +19,16 @@ export default class AnswerButton extends React.Component {
   }
 
   render() {
+    const { onPress, answer, disabled } = this.props;
+
     return (
       <TouchableOpacity
+        disabled={disabled}
         style={[styles.button, this.props.style, this.getAnswerStyle('button')]}
-        onPress={() => this.props.onPress(this.props.answer)}
+        onPress={() => onPress(answer)}
       >
         <Text style={[styles.text, this.getAnswerStyle('text')]}>
-          {this.props.answer.latinChar}
+          {answer.latinChar}
         </Text>
       </TouchableOpacity>
     );

--- a/js/screens/game/AnswerView.js
+++ b/js/screens/game/AnswerView.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import _ from 'lodash';
 import AnswerButton from './AnswerButton';
 
-export default ({ answers, correctAnswer, givenAnswer, checkAnswer }) => {
+export default ({ answers, givenAnswer, checkAnswer, disabled }) => {
   return (
     <View style={styles.answerButtonContainer}>
       {answers.map((syllable, i) => {
@@ -14,6 +14,7 @@ export default ({ answers, correctAnswer, givenAnswer, checkAnswer }) => {
 
         return (
           <AnswerButton
+            disabled={disabled}
             answer={syllable}
             key={i}
             highlight={highlight}

--- a/js/screens/game/index.js
+++ b/js/screens/game/index.js
@@ -7,7 +7,6 @@ import Hearts from './Hearts';
 import Diamonds from './Diamonds';
 import theme from '../../utils/theme';
 import { connect } from '../../context/connect';
-// import { setPersistedStore } from '../../context/utils';
 
 const PAUSE = 500;
 const DEFAULT_LEVEL = 1;
@@ -22,13 +21,14 @@ class Game extends React.Component {
     );
   }
 
-  componentDidUpdate(prevProps) {
-    const { game, unlockedLevel, setupNextSyllable } = this.props;
+  componentDidUpdate() {
+    const { game, setupNextSyllable } = this.props;
     console.log(game);
 
     if (game.pending) {
       setTimeout(() => {
         if (game.lives === 0) {
+          this.props.resetGameState();
           this.props.navigation.navigate('LevelSelection', {
             preselectedLevel: game.level
           });
@@ -40,7 +40,7 @@ class Game extends React.Component {
   }
 
   checkAnswer = givenAnswer => {
-    const { setGivenAnswer, game, navigation } = this.props;
+    const { setGivenAnswer, game } = this.props;
 
     setGivenAnswer({
       ...givenAnswer,
@@ -110,6 +110,7 @@ const mapStateToProps = ({ game, persistedStore }) => ({
 const mapActionToProps = ({ game, persistedStore }) => {
   return {
     setupNextSyllable: game.setupNextSyllable,
+    resetGameState: game.resetGameState,
     setGivenAnswer: game.setGivenAnswer,
     checkGivenAnswer: game.checkGivenAnswer,
     setPersistedStore: persistedStore.setPersistedStore

--- a/js/screens/game/index.js
+++ b/js/screens/game/index.js
@@ -23,12 +23,10 @@ class Game extends React.Component {
 
   componentDidUpdate() {
     const { game, setupNextSyllable } = this.props;
-    console.log(game);
 
     if (game.pending) {
       setTimeout(() => {
         if (game.lives === 0) {
-          this.props.resetGameState();
           this.props.navigation.navigate('LevelSelection', {
             preselectedLevel: game.level
           });
@@ -37,6 +35,10 @@ class Game extends React.Component {
         setupNextSyllable('hiragana', game.level);
       }, PAUSE);
     }
+  }
+
+  componentWillUnmount() {
+    this.props.resetGameState();
   }
 
   checkAnswer = givenAnswer => {
@@ -68,6 +70,7 @@ class Game extends React.Component {
               correctAnswer={game.correctAnswer}
               givenAnswer={game.givenAnswer}
               checkAnswer={this.checkAnswer}
+              disabled={game.status === 'spawnGems'}
             />
             <TouchableOpacity
               onPress={() => navigation.navigate('Pause')}


### PR DESCRIPTION
fixes #11 

* adds a basic `resetGameState` action that currently only resets the players lives and score (that should prevent numerous errors when starting a new level)
* disables the answer buttons while gems are spawning (this also prevents a bunch of possible errors)