### PR TITLE
fix(package): update expo to version 33.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "expo start"
   },
   "dependencies": {
-    "expo": "^32.0.0",
+    "expo": "^33.0.7",
     "json5": "^2.1.0",
     "lodash": "^4.17.5",
     "react": "16.5.0",


### PR DESCRIPTION
See the changes [here](https://github.com/expo/expo/blob/master/CHANGELOG.md#3300). This shouldn't affect us, I'd say let's upgrade and have a look soon how the app runs.

Closes #26